### PR TITLE
reverted accumulation to original non numpy version

### DIFF
--- a/ssrm_test/ssrm_test.py
+++ b/ssrm_test/ssrm_test.py
@@ -261,7 +261,7 @@ def sequential_p_values(
         data, null_probabilities, dirichlet_probability, dirichlet_concentration
     )
     inverse_bayes_factors = 1 / bayes_factors
-    return np.minimum.accumulate(inverse_bayes_factors)
+    return list(accumulate(min, inverse_bayes_factors, 1))
 
 
 def sequential_posteriors(

--- a/ssrm_test/test_ssrm_test.py
+++ b/ssrm_test/test_ssrm_test.py
@@ -24,6 +24,7 @@ from .ssrm_test import (
     log_posterior_predictive,
     multinomiallogpmf,
     posterior_probability,
+    sequential_p_values,
     sequential_posteriors,
     srm_test,
 )
@@ -197,3 +198,14 @@ def test_srm_test():
     null_probabilities = np.array([0.4, 0.4, 0.2])
     mismatch_prob = srm_test(datapoints, null_probabilities)
     assert mismatch_prob >= 0 and mismatch_prob <= 1
+
+
+def test_p_values_decreasing_and_in_range():
+    p_0 = np.array([1 / 3, 1 / 3, 1 / 3])
+    p_1 = np.array([2 / 9, 4 / 9, 3 / 9])
+    sample_size = 40
+    data = multinomial.rvs(1, p_1, size=sample_size)
+    pvals = sequential_p_values(data, p_0)
+    for ix in range(1, sample_size):
+        assert pvals[ix] <= pvals[ix - 1]  # pvals should be non increasing
+        assert 0.0 <= pvals[ix] and pvals[ix] <= 1.0

--- a/ssrm_test/test_ssrm_test.py
+++ b/ssrm_test/test_ssrm_test.py
@@ -208,4 +208,5 @@ def test_p_values_decreasing_and_in_range():
     pvals = sequential_p_values(data, p_0)
     for ix in range(1, sample_size):
         assert pvals[ix] <= pvals[ix - 1]  # pvals should be non increasing
-        assert 0.0 <= pvals[ix] and pvals[ix] <= 1.0
+    for pval in pvals:
+        assert 0.0 <= pval and pval <= 1.0


### PR DESCRIPTION
the accumulation was recently switched to numpy for performance, yet this does not allow you to seed the initial accumulation. This pull request reverts it back to the `toolz` implementation of accumulate