### PR TITLE
docs: Set requirements.txt for docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,4 @@ sphinx:
 python:
     version: 3.7
     install:
-       - method: pip
-         path: .
-         extra_requirements:
-             - docs
+       - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+m2r==0.2.1
+sphinx==2.4.4
+sphinx-rtd-theme==0.4.3


### PR DESCRIPTION
ReadTheDocs does not install the dev dependencies specified in pyproject.toml, so the docs build fails. This PR introduces a workaround by creating a requirements.txt file in the `docs/` dir and updating the `.readthedocs.yml` to point to that file.