### PR TITLE
docs: Install non-dev requirements to generate docs correctly

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,3 +13,5 @@ python:
     version: 3.7
     install:
        - requirements: docs/requirements.txt
+       - method: pip
+         path: .


### PR DESCRIPTION
Sphinx fails to generate module docs because the requirements (non-dev) are not installed.
This PR fixes that.